### PR TITLE
Fix Windows path escaping in escapeShellArg function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,15 @@ const server = new Server(
  * This is a basic implementation and should be replaced with a more robust solution in production.
  */
 function escapeShellArg(arg: string): string {
-  // Replace all single quotes with the sequence: '"'"'
-  // This ensures the argument is properly quoted in shell commands
-  return `'${arg.replace(/'/g, "'\"'\"'")}'`;
+  if (process.platform === 'win32') {
+    // This covers ALL Windows versions (32-bit, 64-bit, etc.)
+    return `"${arg.replace(/"/g, '""')}"`;
+  } else {
+    // Unix/Linux/macOS
+    return `'${arg.replace(/'/g, "'\"'\"'")}'`;
+  }
 }
+
 
 /**
  * Execute a command with isolated streams to prevent external processes


### PR DESCRIPTION
## Description
This PR fixes path escaping issues on Windows that were causing "os error 123" errors.

## Problem
The `escapeShellArg` function was using Unix-style single quotes for all platforms, which doesn't work correctly on Windows.

## Solution
- Detect the platform using `process.platform`
- Use double quotes for Windows (`"path"`)
- Use single quotes for Unix/Linux/macOS (`'path'`)
- Properly escape quotes within the paths

## Testing
Tested on Windows 11 with various ripgrep operations including:
- Basic search
- Search with spaces in patterns
- Case insensitive search
- Count matches
- List files
- Advanced search with context
- File type filtering

All operations now work correctly on Windows.